### PR TITLE
Warn when panels supplied via the landing page are filtered out.

### DIFF
--- a/R/iSEE-main.R
+++ b/R/iSEE-main.R
@@ -371,6 +371,9 @@ iSEE <- function(se,
                     requested <- vapply(INITIAL, .encodedName, "")
                     available <- c(vapply(initial, .encodedName, ""), vapply(extra, .encodedName, ""))
                     keep <- requested %in% available
+                    if (!all(keep)) {
+                        warning("not all requested Panels exist in 'initial' or 'extra'")
+                    }
                     INITIAL <- INITIAL[keep]
                 }
                 .initialize_server(SE, initial=INITIAL, extra=extra, colormap=colormap,

--- a/R/iSEE-main.R
+++ b/R/iSEE-main.R
@@ -110,12 +110,13 @@
 #'
 #' @export
 #' @importFrom shinydashboard dashboardBody dashboardHeader dashboardPage
-#' dashboardSidebar menuItem tabBox valueBox valueBoxOutput dropdownMenu notificationItem
+#' dashboardSidebar menuItem tabBox valueBox valueBoxOutput dropdownMenu 
+#' notificationItem
 #' @importFrom utils packageVersion
 #' @importFrom shinyjs useShinyjs
 #' @importFrom rintrojs introjsUI
 #' @importFrom shiny reactiveValues uiOutput actionButton shinyApp
-#' HTML icon tags includeCSS isolate
+#' HTML icon tags includeCSS isolate showNotification
 iSEE <- function(se,
     initial=NULL,
     extra=NULL,
@@ -372,7 +373,7 @@ iSEE <- function(se,
                     available <- c(vapply(initial, .encodedName, ""), vapply(extra, .encodedName, ""))
                     keep <- requested %in% available
                     if (!all(keep)) {
-                        warning("not all requested Panels exist in 'initial' or 'extra'")
+                        showNotification("not all requested Panels exist in 'initial' or 'extra'", type="warning")
                     }
                     INITIAL <- INITIAL[keep]
                 }


### PR DESCRIPTION
Try to reduce confusion when that happens for an instance launched via a landing page.