### PR TITLE
Prepared interface elements, class slots for global selection.

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -127,13 +127,19 @@ collated[.selectColSource] <- "character"
 
 collated[.dataParamBoxOpen] <- "logical"
 
+.selectRowGlobal <- "GlobalRowSelection"
 .selectRowType <- "RowSelectionType"
 .selectRowSaved <- "RowSelectionSaved"
+
+collated[.selectRowGlobal] <- "logical"
+collated[.selectRowType] <- "character"
+collated[.selectRowSaved] <- "integer"
+
+.selectColGlobal <- "GlobalColumnSelection"
 .selectColType <- "ColumnSelectionType"
 .selectColSaved <- "ColumnSelectionSaved"
 
-collated[.selectRowType] <- "character"
-collated[.selectRowSaved] <- "integer"
+collated[.selectColGlobal] <- "logical"
 collated[.selectColType] <- "character"
 collated[.selectColSaved] <- "integer"
 

--- a/R/family_Panel.R
+++ b/R/family_Panel.R
@@ -160,6 +160,9 @@ setMethod("initialize", "Panel", function(.Object, ...) {
     args <- .empty_default(args, .selectColType, .selectMultiActiveTitle)
     args <- .empty_default(args, .selectColSaved, 0L)
 
+    args <- .empty_default(args, .selectRowGlobal, FALSE)
+    args <- .empty_default(args, .selectColGlobal, FALSE)
+
     args <- .empty_default(args, .dataParamBoxOpen, FALSE)
 
     do.call(callNextMethod, c(list(.Object), args))
@@ -167,7 +170,10 @@ setMethod("initialize", "Panel", function(.Object, ...) {
 
 setValidity2("Panel", function(object) {
     msg <- character(0)
-    msg <- .valid_logical_error(msg, object, c(.selectParamBoxOpen, .dataParamBoxOpen))
+
+    msg <- .valid_logical_error(msg, object, c(.selectParamBoxOpen, .dataParamBoxOpen,
+        .selectRowGlobal, .selectColGlobal))
+
     msg <- .single_string_error(msg, object, c(.selectRowSource, .selectColSource))
 
     msg <- .valid_number_error(msg, object, .organizationHeight, lower=height_limits[1], upper=height_limits[2])

--- a/R/interface_select.R
+++ b/R/interface_select.R
@@ -62,11 +62,11 @@
 
         .define_selection_choices(x, by_field=.selectRowSource,
             type_field=.selectRowType, saved_field=.selectRowSaved,
-            selectable=row_selectable, "row"),
+            global_field=.selectRowGlobal, selectable=row_selectable, "row"),
 
         .define_selection_choices(x, by_field=.selectColSource,
             type_field=.selectColType, saved_field=.selectColSaved,
-            selectable=col_selectable, "column"),
+            global_field=.selectColGlobal, selectable=col_selectable, "column"),
 
         ...
     )
@@ -148,12 +148,18 @@
 #' @rdname INTERNAL_create_selection_param_box
 #' @importFrom shiny tagList radioButtons selectizeInput
 .define_selection_choices <- function(x, by_field, type_field,
-    saved_field, selectable, source_type="row")
+    saved_field, global_field, selectable, source_type="row")
 {
     select_type <- paste0(.getEncodedName(x), "_", type_field)
+    select_global <- paste0(.getEncodedName(x), "_", global_field)
 
     tagList(
-        .define_selection_transmitter(x, by_field, selectable, source_type),
+        checkboxInput(select_global, label=paste("Use global", source_type, "selection"),
+            value=x[[global_field]]),
+            
+        .conditional_on_check_solo(select_global, FALSE,
+            .define_selection_transmitter(x, by_field, selectable, source_type)
+        ),
 
         .radioButtonsHidden(
             x, field=type_field, label=NULL, inline=TRUE,


### PR DESCRIPTION
Deals with #377. Note that it is best that the global on/off does not interfere with the selection source, only modifying the underlying graph by adding or removing the link and retriggering the necessary plotting events.