### PR TITLE
pkgdown needs to see the full path to external PNG files to embed in vignettes

### DIFF
--- a/vignettes/basic.Rmd
+++ b/vignettes/basic.Rmd
@@ -56,10 +56,6 @@ stopifnot(requireNamespace("htmltools"))
 htmltools::tagList(rmarkdown::html_dependency_font_awesome())
 ```
 
-```{r, eval=!exists("SCREENSHOT"), include=FALSE}
-SCREENSHOT <- function(x, ...) knitr::include_graphics(file.path("screenshots", x))
-```
-
 ```{r, echo=FALSE, out.width='50%', fig.align='center'}
 knitr::include_graphics(path = system.file(package="iSEE", "www/iSEE.png", mustWork=TRUE))
 ```
@@ -156,7 +152,7 @@ shiny::runApp(app)
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("basic-demo.png")
+knitr::include_graphics("screenshots/basic-demo.png")
 ```
 
 By default, the app starts with a dashboard that contains one panel or table of each type.

--- a/vignettes/configure.Rmd
+++ b/vignettes/configure.Rmd
@@ -57,10 +57,6 @@ htmltools::tagList(rmarkdown::html_dependency_font_awesome())
 sce <- readRDS("sce.rds")
 ```
 
-```{r, eval=!exists("SCREENSHOT"), include=FALSE}
-SCREENSHOT <- function(x, ...) knitr::include_graphics(file.path("screenshots", x))
-```
-
 # Changing the default start configuration
 
 The default start configuration with one plot of each type may not always be the most appropriate.
@@ -81,7 +77,7 @@ app <- iSEE(sce, initial=list(
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-FAP-basic.png")
+knitr::include_graphics("screenshots/configure-FAP-basic.png")
 ```
 
 The genes to show on the Y-axis in the two plots can be specified via the `featAssayArgs` argument to `iSEE`. This is a `DataFrame`, specifying the initial parameters for each plot.
@@ -95,7 +91,7 @@ app <- iSEE(sce, initial=list(
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-FAP-preset-genes.png")
+knitr::include_graphics("screenshots/configure-FAP-preset-genes.png")
 ```
 
 This will open the app with two feature assay plots, showing the selected genes.
@@ -126,7 +122,7 @@ app <- iSEE(sce, initial=list(
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-CDP-basic.png")
+knitr::include_graphics("screenshots/configure-CDP-basic.png")
 ```
 
 ## Setting the X-axis {#xaxis}
@@ -173,7 +169,7 @@ app <- iSEE(sce, initial=list(fex1, fex2, fex3, fex4, rex))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-FAP-xaxis.png")
+knitr::include_graphics("screenshots/configure-FAP-xaxis.png")
 ```
 
 Note how _Example 3b_ requires an active _row data table_ as a source of selection.
@@ -193,7 +189,7 @@ app <- iSEE(sce, initial=list(
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-ReDP-basic.png")
+knitr::include_graphics("screenshots/configure-ReDP-basic.png")
 ```
 
 We refer users to the `?redDimPlotDefaults` help page to learn more about the choices of default parameters for _reduced dimension plot_ panels.
@@ -210,7 +206,7 @@ app <- iSEE(sce, initial=list(
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-FAP-assay.png")
+knitr::include_graphics("screenshots/configure-FAP-assay.png")
 ```
 
 # Visual parameters
@@ -251,7 +247,7 @@ app <- iSEE(sce, initial=list(cdp, cdp2))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-CDP-visual.png")
+knitr::include_graphics("screenshots/configure-CDP-visual.png")
 ```
 
 Note that for this demonstration, we facilitate visualization of the preconfigured arguments by setting `VisualChoices` to display both the `"Color"` and `"Shape"` UI panels.
@@ -275,7 +271,7 @@ app <- iSEE(sce, initial=list(cdp, cdp2))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-CDP-linked-visual.png")
+knitr::include_graphics("screenshots/configure-CDP-linked-visual.png")
 ```
 
 Note that points may only be shaped by a categorical variable.
@@ -302,7 +298,7 @@ app <- iSEE(sce, initial=list(cdp, cdp2, cdp3))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-CDP-facets.png")
+knitr::include_graphics("screenshots/configure-CDP-facets.png")
 ```
 
 # Selection parameters
@@ -356,7 +352,7 @@ app <- iSEE(sce, initial=list(cdArgs, rdArgs))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-ReDP-select.png")
+knitr::include_graphics("screenshots/configure-ReDP-select.png")
 ```
 
 Note that in the example above, we chose to color selected data points in the receiver panel, by setting the `SelectionEffect` argument to `"Color"`,
@@ -387,7 +383,7 @@ app <- iSEE(sce, initial=list(cdArgs, rdArgs))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("configure-ReDP-lasso.png")
+knitr::include_graphics("screenshots/configure-ReDP-lasso.png")
 ```
 
 # Writing your own tour

--- a/vignettes/custom.Rmd
+++ b/vignettes/custom.Rmd
@@ -56,10 +56,6 @@ htmltools::tagList(rmarkdown::html_dependency_font_awesome())
 sce <- readRDS('sce.rds')
 ```
 
-```{r, eval=!exists("SCREENSHOT"), include=FALSE}
-SCREENSHOT <- function(x, ...) knitr::include_graphics(file.path("screenshots", x))
-```
-
 # Background
 
 Users can define their own custom plots or tables to include in the `iSEE` interface [@kra2018iSEE]. 
@@ -186,7 +182,7 @@ app <- iSEE(sce, initial=list(cdp, custom.p))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("custom-plot.png")
+knitr::include_graphics("screenshots/custom-plot.png")
 ```
 
 The most interesting aspect of `createCustomPlot()` is that the UI elements for modifying the optional arguments in `CUSTOM_DIMRED` are also automatically generated.
@@ -259,7 +255,7 @@ app <- iSEE(sce, initial=list(rdp, custom.t))
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("custom-table.png")
+knitr::include_graphics("screenshots/custom-table.png")
 ```
 
 # Handling active and saved selections
@@ -339,7 +335,7 @@ app <- iSEE(sce, initial=list(rdp,
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("custom-heat.png")
+knitr::include_graphics("screenshots/custom-heat.png")
 ```
 
 # Advanced extensions

--- a/vignettes/ecm.Rmd
+++ b/vignettes/ecm.Rmd
@@ -56,10 +56,6 @@ htmltools::tagList(rmarkdown::html_dependency_font_awesome())
 sce <- readRDS('sce.rds')
 ```
 
-```{r, eval=!exists("SCREENSHOT"), include=FALSE}
-SCREENSHOT <- function(x, ...) knitr::include_graphics(file.path("screenshots", x))
-```
-
 # Background
 
 `r Biocpkg("iSEE")` coordinates the coloration in every plot via the `ExperimentColorMap` class [@kra2018iSEE].
@@ -207,7 +203,7 @@ shiny::runApp(app)
 ```
 
 ```{r, echo=FALSE}
-SCREENSHOT("ecm-demo.png")
+knitr::include_graphics("screenshots/ecm-demo.png")
 ```
 
 Now, choose to color cells by `Column data` and select `passes_qc_checks_s`.


### PR DESCRIPTION

`pkgdown` needs to see the full path to PNG files, to understand that it needs to copy them into the website

Deleted `SCREENSHOT()` and replaced by `knitr::include_graphics("screenshots/file.png")`

Sources:

- https://github.com/r-lib/pkgdown/blob/16231d9a2b2c47b6616ad32678917918b8621a62/R/build-articles.R#L86
