### PR TITLE
Simplify the .renderOutput contract with respect to varname

### DIFF
--- a/R/createCustomPanels.R
+++ b/R/createCustomPanels.R
@@ -154,12 +154,13 @@ createCustomPlot <- function(FUN, restrict=NULL, className="CustomPlot",
     setMethod(".renderOutput", className, function(x, se, output, pObjects, rObjects) {
         plot_name <- .getEncodedName(x)
         force(se) # defensive programming to avoid difficult bugs due to delayed evaluation.
+
         # nocov start
         output[[plot_name]] <- renderPlot({
-            p.out <- .retrieveOutput(plot_name, se, pObjects, rObjects)
-            p.out$contents
+            .retrieveOutput(plot_name, se, pObjects, rObjects)$contents
         })
         # nocov end
+
     }, where=where)
 
     generator

--- a/R/family_DotPlot.R
+++ b/R/family_DotPlot.R
@@ -137,7 +137,8 @@
 #' \itemize{
 #' \item \code{\link{.generateOutput}(x, se, all_memory, all_contents)} returns a list containing \code{contents}, a data.frame with one row per point currently present in the plot;
 #' \code{plot}, a \link{ggplot} object;
-#' and \code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot}.
+#' \code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot};
+#' and \code{varname}, a string containing the name of the variable in \code{commands} that was used to obtain \code{contents}.
 #' \item \code{\link{.generateDotPlot}(x, labels, envir)} returns a list containing \code{plot} and \code{commands}, as described above.
 #' This is called within \code{\link{.generateOutput}} for all \linkS4class{DotPlot} instances by default.
 #' Methods are also guaranteed to generate a \code{dot.plot} variable in \code{envir} containing the \link{ggplot} object corresponding to \code{plot}.
@@ -409,9 +410,7 @@ setMethod(".renderOutput", "DotPlot", function(x, se, output, pObjects, rObjects
 
     # nocov start
     output[[plot_name]] <- renderPlot({
-        p.out <- .retrieveOutput(plot_name, se, pObjects, rObjects)
-        pObjects$varname[[plot_name]] <- "plot.data"
-        p.out$plot
+        .retrieveOutput(plot_name, se, pObjects, rObjects)$plot
     })
     # nocov end
 
@@ -561,7 +560,7 @@ setMethod(".generateOutput", "DotPlot", function(x, se, all_memory, all_contents
     plot_out <- .generateDotPlot(x, all_labels, plot_env)
     all_cmds$plot <- plot_out$commands
 
-    list(commands=all_cmds, contents=panel_data, plot=plot_out$plot)
+    list(commands=all_cmds, contents=panel_data, plot=plot_out$plot, varname="plot.data")
 })
 
 #' @export

--- a/R/family_Table.R
+++ b/R/family_Table.R
@@ -32,7 +32,8 @@
 #' \item \code{\link{.renderOutput}(x, se, output, pObjects, rObjects)} will add a rendered \code{\link{datatable}} object to \code{output}.
 #' This will also call the equivalent \linkS4class{Panel} method to render the panel information testboxes.
 #' \item \code{\link{.generateOutput}(x, se, all_memory, all_contents)} returns a list containing \code{contents}, a data.frame with one row per point currently present in the table;
-#' and \code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot}.
+#' \code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot};
+#' and \code{varname}, a string specifying the name of the variable in \code{commands} used to generate \code{contents}.
 #' \item \code{\link{.exportOutput}(x, se, all_memory, all_contents)} will create a CSV file containing the current table, and return a string containing the path to that file. 
 #' This assumes that the \code{contents} field returned by \code{\link{.generateOutput}} is a data.frame or can be coerced into one.
 #' }

--- a/R/outputs_table.R
+++ b/R/outputs_table.R
@@ -36,7 +36,6 @@
 
         t.out <- .retrieveOutput(panel_name, se, pObjects, rObjects)
         full_tab <- t.out$contents
-        pObjects$varname[[panel_name]] <- "tab"
 
         chosen <- param_choices[[.TableSelected]]
         search <- param_choices[[.TableSearch]]
@@ -107,7 +106,8 @@
 #'
 #' @return
 #' A list containing \code{commands}, a list of the commands required to produce the data.frame;
-#' and \code{contents}, a data.frame of the current contents of the Table.
+#' \code{contents}, a data.frame of the current contents of the Table;
+#' and \code{varname}, a string containing the name of the variable in \code{commands} used to generate \code{contents}.
 #'
 #' @author Aaron Lun
 #'
@@ -122,5 +122,5 @@
     # Creating the table and storing it.
     tab_cmds <- .generateTable(x, eval_env)
 
-    list(commands=list(select_cmds, tab_cmds), contents=eval_env$tab)
+    list(commands=list(select_cmds, tab_cmds), contents=eval_env$tab, varname="tab")
 }

--- a/R/panel_ComplexHeatmapPlot.R
+++ b/R/panel_ComplexHeatmapPlot.R
@@ -437,7 +437,7 @@ setMethod(".generateOutput", "ComplexHeatmapPlot", function(x, se, all_memory, a
     annotation_legend_side <- sprintf('annotation_legend_side=%s', deparse(tolower(x[[.plotLegendPosition]])))
     all_cmds[["draw"]] <- sprintf("ComplexHeatmap::draw(hm, %s, %s)", heatmap_legend_side, annotation_legend_side)
 
-    list(commands=all_cmds, contents=plot_env$plot.data, plot=plot_out)
+    list(commands=all_cmds, contents=plot_env$plot.data, plot=plot_out, varname="plot.data")
 })
 
 #' @export
@@ -450,8 +450,6 @@ setMethod(".renderOutput", "ComplexHeatmapPlot", function(x, se, output, pObject
     # nocov start
     output[[plot_name]] <- renderPlot({
         p.out <- .retrieveOutput(plot_name, se, pObjects, rObjects)
-        pObjects$varname[[plot_name]] <- "plot.data"
-
         tmp.env <- new.env()
         tmp.env$hm <- p.out$plot
         eval(parse(text=p.out$commands[["draw"]]), envir=tmp.env)

--- a/R/utils_reactive.R
+++ b/R/utils_reactive.R
@@ -41,17 +41,19 @@
 #' @rdname retrieveOutput
 .retrieveOutput <- function(panel_name, se, pObjects, rObjects) {
     .trackUpdate(panel_name, rObjects)
+    curpanel <- pObjects$memory[[panel_name]]
 
     if (length(pObjects$cached[[panel_name]])!=0L) {
         output <- pObjects$cached[[panel_name]]
         pObjects$cached[panel_name] <- list(NULL)
     } else {
-        output <- .generateOutput(pObjects$memory[[panel_name]], se, 
+        output <- .generateOutput(curpanel, se, 
             all_memory=pObjects$memory, all_contents=pObjects$contents)
     }
 
     pObjects$commands[[panel_name]] <- output$commands
     pObjects$contents[[panel_name]] <- output$contents
+    pObjects$varname[[panel_name]] <- output$varname # can be NULL for non-transmitting panels.
 
     output
 }

--- a/man/DotPlot-class.Rd
+++ b/man/DotPlot-class.Rd
@@ -166,7 +166,8 @@ For generating the output:
 \itemize{
 \item \code{\link{.generateOutput}(x, se, all_memory, all_contents)} returns a list containing \code{contents}, a data.frame with one row per point currently present in the plot;
 \code{plot}, a \link{ggplot} object;
-and \code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot}.
+\code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot};
+and \code{varname}, a string containing the name of the variable in \code{commands} that was used to obtain \code{contents}.
 \item \code{\link{.generateDotPlot}(x, labels, envir)} returns a list containing \code{plot} and \code{commands}, as described above.
 This is called within \code{\link{.generateOutput}} for all \linkS4class{DotPlot} instances by default.
 Methods are also guaranteed to generate a \code{dot.plot} variable in \code{envir} containing the \link{ggplot} object corresponding to \code{plot}.

--- a/man/Table-class.Rd
+++ b/man/Table-class.Rd
@@ -49,7 +49,8 @@ This will also call the equivalent \linkS4class{Panel} method.
 \item \code{\link{.renderOutput}(x, se, output, pObjects, rObjects)} will add a rendered \code{\link{datatable}} object to \code{output}.
 This will also call the equivalent \linkS4class{Panel} method to render the panel information testboxes.
 \item \code{\link{.generateOutput}(x, se, all_memory, all_contents)} returns a list containing \code{contents}, a data.frame with one row per point currently present in the table;
-and \code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot}.
+\code{commands}, a list of character vector containing the R commands required to generate \code{contents} and \code{plot};
+and \code{varname}, a string specifying the name of the variable in \code{commands} used to generate \code{contents}.
 \item \code{\link{.exportOutput}(x, se, all_memory, all_contents)} will create a CSV file containing the current table, and return a string containing the path to that file. 
 This assumes that the \code{contents} field returned by \code{\link{.generateOutput}} is a data.frame or can be coerced into one.
 }

--- a/tests/testthat/test_plotting.R
+++ b/tests/testthat/test_plotting.R
@@ -27,7 +27,7 @@ test_that(".make_redDimPlot/.scatter_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -65,7 +65,7 @@ test_that(".make_colDataPlot/.scatter_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -100,7 +100,7 @@ test_that(".make_colDataPlot/.violin_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -138,7 +138,7 @@ test_that(".make_colDataPlot/.square_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -179,7 +179,7 @@ test_that(".make_rowDataPlot/.scatter_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -223,7 +223,7 @@ test_that(".make_rowDataPlot/.violin_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -271,7 +271,7 @@ test_that(".make_rowDataPlot/.square_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -300,7 +300,7 @@ test_that(".make_rowDataPlot/.square_plot produce a valid xy with color",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -332,7 +332,7 @@ test_that(".make_featAssayPlot/.violin_plot produce a valid list",{
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")
@@ -404,7 +404,7 @@ test_that(".make_sampAssayPlot works with X covariate set to None", {
 
     # return value is a named list
     expect_type(p.out, "list")
-    expect_named(p.out, c("commands", "contents", "plot"))
+    expect_named(p.out, c("commands", "contents", "plot", "varname"))
 
     # cmd value is a named list
     expect_type(p.out$commands, "list")


### PR DESCRIPTION
Mostly by pushing the work onto .retrieveOutput and .generateOutput.