### PR TITLE
Pass contents to .singleSelectionValue instead of pObjects.

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -802,7 +802,7 @@ NULL
 setGeneric(".singleSelectionDimension", function(x) standardGeneric(".singleSelectionDimension"))
 
 #' @export
-setGeneric(".singleSelectionValue", function(x, pObjects) standardGeneric(".singleSelectionValue"))
+setGeneric(".singleSelectionValue", function(x, contents) standardGeneric(".singleSelectionValue"))
 
 #' @export
 setGeneric(".singleSelectionSlots", function(x) standardGeneric(".singleSelectionSlots"))

--- a/R/family_DotPlot.R
+++ b/R/family_DotPlot.R
@@ -165,7 +165,7 @@
 #' The active selection is returned if \code{index=NA}, otherwise one of the saved selection is returned.
 #' \item \code{\link{.multiSelectionActive}(x)} returns \code{x[["BrushData"]]} or \code{NULL} if there is no brush or closed lasso.
 #' \item \code{\link{.multiSelectionClear}(x)} returns \code{x} after setting the \code{BrushData} slot to an empty list.
-#' \item \code{\link{.singleSelectionValue}(x)} returns the name of the first selected element in the active brush.
+#' \item \code{\link{.singleSelectionValue}(x, contents)} returns the name of the first selected element in the active brush.
 #' If no brush is active, \code{NULL} is returned instead.
 #' \item \code{\link{.singleSelectionSlots}(x)} will return a list specifying the slots that can be updated by single selections in transmitter panels, mostly related to the choice of coloring parameters.
 #' This includes the output of \code{callNextMethod}.
@@ -471,9 +471,9 @@ setMethod(".multiSelectionCommands", "DotPlot", function(x, index) {
 })
 
 #' @export
-setMethod(".singleSelectionValue", "DotPlot", function(x, pObjects) {
+setMethod(".singleSelectionValue", "DotPlot", function(x, contents) {
     plot_name <- .getEncodedName(x)
-    chosen <- .get_brushed_points(pObjects$contents[[plot_name]], x[[.brushData]])
+    chosen <- .get_brushed_points(contents, x[[.brushData]])
     if (!length(chosen)) NULL else chosen[1]
 })
 

--- a/R/family_Table.R
+++ b/R/family_Table.R
@@ -46,7 +46,7 @@
 #' If both contain only empty strings, a \code{NULL} is returned instead.
 #' \item \code{\link{.multiSelectionCommands}(x, index)} returns a character vector of R expressions that - when evaluated - return a character vector of the row names of the table after applying all search filters.
 #' The value of \code{index} is ignored.
-#' \item \code{\link{.singleSelectionValue}(x, pObjects)} returns the name of the row that was last selected in the \code{\link{datatable}} widget.
+#' \item \code{\link{.singleSelectionValue}(x, contents)} returns the name of the row that was last selected in the \code{\link{datatable}} widget.
 #' }
 #'
 #' Unless explicitly specialized above, all methods from the parent class \linkS4class{Panel} are also available.
@@ -114,7 +114,7 @@ setMethod(".multiSelectionActive", "Table", function(x) {
 })
 
 #' @export
-setMethod(".singleSelectionValue", "Table", function(x, pObjects) {
+setMethod(".singleSelectionValue", "Table", function(x, contents) {
     x[[.TableSelected]]
 })
 

--- a/R/observers_dimname.R
+++ b/R/observers_dimname.R
@@ -34,7 +34,7 @@
     observeEvent(rObjects[[dimname_name]], {
         instance <- pObjects$memory[[panel_name]]
 
-        chosen <- .singleSelectionValue(instance, pObjects)
+        chosen <- .singleSelectionValue(instance, pObjects$contents[[panel_name]])
         if (is.null(chosen)) {
             return(NULL)
         }
@@ -159,7 +159,7 @@
         # Updating the selection, based on the currently selected row.
         if (tab!=.noSelection) {
             old_selected <- pObjects$memory[[panel_name]][[name_field]]
-            new_selected <- .singleSelectionValue(pObjects$memory[[tab]], pObjects)
+            new_selected <- .singleSelectionValue(pObjects$memory[[tab]], pObjects$contents[[tab]])
 
             if (!is.null(new_selected) && new_selected != old_selected) {
                 all_choices <- rownames(pObjects$contents[[tab]])

--- a/man/DotPlot-class.Rd
+++ b/man/DotPlot-class.Rd
@@ -194,7 +194,7 @@ For controlling selections:
 The active selection is returned if \code{index=NA}, otherwise one of the saved selection is returned.
 \item \code{\link{.multiSelectionActive}(x)} returns \code{x[["BrushData"]]} or \code{NULL} if there is no brush or closed lasso.
 \item \code{\link{.multiSelectionClear}(x)} returns \code{x} after setting the \code{BrushData} slot to an empty list.
-\item \code{\link{.singleSelectionValue}(x)} returns the name of the first selected element in the active brush.
+\item \code{\link{.singleSelectionValue}(x, contents)} returns the name of the first selected element in the active brush.
 If no brush is active, \code{NULL} is returned instead.
 \item \code{\link{.singleSelectionSlots}(x)} will return a list specifying the slots that can be updated by single selections in transmitter panels, mostly related to the choice of coloring parameters.
 This includes the output of \code{callNextMethod}.

--- a/man/Table-class.Rd
+++ b/man/Table-class.Rd
@@ -63,7 +63,7 @@ Transmission of a selection to a Table will manifest as a subsetting of the rows
 If both contain only empty strings, a \code{NULL} is returned instead.
 \item \code{\link{.multiSelectionCommands}(x, index)} returns a character vector of R expressions that - when evaluated - return a character vector of the row names of the table after applying all search filters.
 The value of \code{index} is ignored.
-\item \code{\link{.singleSelectionValue}(x, pObjects)} returns the name of the row that was last selected in the \code{\link{datatable}} widget.
+\item \code{\link{.singleSelectionValue}(x, contents)} returns the name of the row that was last selected in the \code{\link{datatable}} widget.
 }
 
 Unless explicitly specialized above, all methods from the parent class \linkS4class{Panel} are also available.

--- a/man/output-generics.Rd
+++ b/man/output-generics.Rd
@@ -84,15 +84,21 @@ The following arguments are required:
 Methods for this generic should return a list containing:
 \itemize{
 \item \code{contents}, some arbitrary content for the panel (usually a data.frame).
-This is used during app initialization to ensure that \code{pObjects$contents} of transmitter panels is filled before rendering their children.
 It should be of a structure that allows it to be cross-referenced against the output of \code{\link{.multiSelectionActive}} to determine the selected rows/columns.
+This is used to ensure that the \code{pObjects$contents} of a panel is populated before attempting to render their children (i.e., those that receive a multiple selection from the current panel).
 \item \code{commands}, a list of character vectors of R commands that, when executed, produces the contents of the panel and any displayed output (e.g., a \link{ggplot} object).
 Developers should write these commands as if the evaluation environment only contains the SummarizedExperiment \code{se} and ExperimentColorMap \code{colormap}.
+\item \code{varname}, a string specifying the name of the variable in \code{commands} used to generate \code{contents}.
+This is used to fulfill code tracking obligations.
 }
 The output list may contain any number of other fields that can be used by \code{\link{.renderOutput}} but are otherwise ignored.
 
 We suggest implementing this method using \code{\link{eval}(\link{parse}(text=...))} calls, which enables easy construction and evaluation of the commands and contents at the same time.
-We also strongly recommend the use of the \code{\link{.processMultiSelections}} function for easily processing the multiple selection parameters.
+A convenient wrapper for this call is provided by the \code{\link{.textEval}} utility.
+
+The \code{all_memory} and \code{all_contents} arguments are provided for the sole purpose of determining what multiple selections are being received by \code{x}.
+We strongly recommend passing them onto \code{\link{.processMultiSelections}} to do the heavy lifting.
+It would be unusual and inadvisable to use these arguments for any other information sharing across panels.
 }
 
 \section{Exporting content}{

--- a/tests/testthat/test_api.R
+++ b/tests/testthat/test_api.R
@@ -296,8 +296,7 @@ context(".singleSelectionValue")
 test_that(".singleSelectionValue handles DotPlot", {
 
     x <- ReducedDimensionPlot(PanelId=1L)
-    pObjects <- new.env()
-    pObjects$contents[["ReducedDimensionPlot1"]] <- data.frame(X=1, Y=seq_len(100), row.names = paste0("X", seq_len(100)))
+    contents <- data.frame(X=1, Y=seq_len(100), row.names = paste0("X", seq_len(100)))
 
     x[[iSEE:::.brushData]] <- list(
         xmin = 0.7, xmax = 1.3, ymin = 1, ymax = 50,
@@ -306,7 +305,7 @@ test_that(".singleSelectionValue handles DotPlot", {
         brushId = "ReducedDimensionPlot1_Brush",
         outputId = "ReducedDimensionPlot1")
 
-    out <- .singleSelectionValue(x, pObjects)
+    out <- .singleSelectionValue(x, contents)
     expect_identical(out, "X1")
 
     # Brush does not include any data point
@@ -317,7 +316,7 @@ test_that(".singleSelectionValue handles DotPlot", {
         brushId = "ReducedDimensionPlot1_Brush",
         outputId = "ReducedDimensionPlot1")
 
-    out <- .singleSelectionValue(x, pObjects)
+    out <- .singleSelectionValue(x, contents)
     expect_null(out)
 })
 


### PR DESCRIPTION
Avoid potential privilege escalation from unnecessary write access.