### PR TITLE
Enforce sensible defaults for the dynamic selection setting.

### DIFF
--- a/R/family_ColumnDotPlot.R
+++ b/R/family_ColumnDotPlot.R
@@ -111,6 +111,10 @@ setMethod("initialize", "ColumnDotPlot", function(.Object, ...) {
 
     args <- .emptyDefault(args, .sizeByColData, NA_character_)
 
+    # Defensive measure to avoid problems with cyclic graphs 
+    # that the user doesn't have permissions to change!
+    args <- .emptyDefault(args, .selectRowDynamic, FALSE)
+
     do.call(callNextMethod, c(list(.Object), args))
 })
 

--- a/R/family_ColumnTable.R
+++ b/R/family_ColumnTable.R
@@ -66,6 +66,18 @@
 NULL
 
 #' @export
+#' @importFrom methods callNextMethod
+setMethod("initialize", "ColumnTable", function(.Object, ...) {
+    args <- list(...)
+
+    # Defensive measure to avoid problems with cyclic graphs 
+    # that the user doesn't have permissions to change!
+    args <- .emptyDefault(args, .selectRowDynamic, FALSE)
+
+    do.call(callNextMethod, c(list(.Object), args))
+})
+
+#' @export
 setMethod(".refineParameters", "ColumnTable", function(x, se) {
     x <- callNextMethod()
     if (is.null(x)) {

--- a/R/family_RowDotPlot.R
+++ b/R/family_RowDotPlot.R
@@ -110,6 +110,10 @@ setMethod("initialize", "RowDotPlot", function(.Object, ...) {
 
     args <- .emptyDefault(args, .sizeByRowData, NA_character_)
 
+    # Defensive measure to avoid problems with cyclic graphs
+    # that the user doesn't have permissions to change!
+    args <- .emptyDefault(args, .selectColDynamic, FALSE)
+
     do.call(callNextMethod, c(list(.Object), args))
 })
 

--- a/R/family_RowTable.R
+++ b/R/family_RowTable.R
@@ -66,6 +66,18 @@
 NULL
 
 #' @export
+#' @importFrom methods callNextMethod
+setMethod("initialize", "RowTable", function(.Object, ...) {
+    args <- list(...)
+
+    # Defensive measure to avoid problems with cyclic graphs 
+    # that the user doesn't have permissions to change!
+    args <- .emptyDefault(args, .selectColDynamic, FALSE)
+
+    do.call(callNextMethod, c(list(.Object), args))
+})
+
+#' @export
 setMethod(".refineParameters", "RowTable", function(x, se) {
     x <- callNextMethod()
     if (is.null(x)) {


### PR DESCRIPTION
This fixes a nasty bug:

- Set `iSEEOptions$set(dynamic.selections.multiple=TRUE)` 
- Make a multiple row selection on some panel X, e.g., a `RowDataPlot`.
- Any column-based panels (say, panel Y) will auto-set their row multiple selections to panel X. 

Normally this isn't a big issue, but if X takes a column selection, then you now have an unnecessary circularity whenever you try to make a selection on Y. This is most problematic if X is a `DifferentialStatisticsTable`.