### PR TITLE
Hide more irrelevant UI elements for tables.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# iSEE 2.1.10
+
+* Avoid transmitting multiple selections for Tables when the number of columns change.
+* Hide irrelevant UI elements for Table multiple selections.
+
 # iSEE 2.1.9
 
 * Improved documentation for generics and classes.

--- a/R/family_ColumnTable.R
+++ b/R/family_ColumnTable.R
@@ -105,7 +105,7 @@ setMethod(".singleSelectionDimension", "ColumnTable", function(x) "sample")
 
 #' @export
 setMethod(".hideInterface", "ColumnTable", function(x, field) {
-    if (field %in% c(.selectRowSource, .selectRowType, .selectRowSaved)) {
+    if (field %in% c(.selectRowSource, .selectRowType, .selectRowSaved, .selectRowDynamic)) {
         TRUE
     } else {
         callNextMethod()

--- a/R/family_RowTable.R
+++ b/R/family_RowTable.R
@@ -99,7 +99,7 @@ setMethod(".createObservers", "RowTable", function(x, se, input, session, pObjec
 
 #' @export
 setMethod(".hideInterface", "RowTable", function(x, field) {
-    if (field %in% c(.selectColSource, .selectColType, .selectColSaved)) {
+    if (field %in% c(.selectColSource, .selectColType, .selectColSaved, .selectColDynamic)) {
         TRUE
     } else {
         callNextMethod()

--- a/R/observers_table.R
+++ b/R/observers_table.R
@@ -69,11 +69,19 @@
     # nocov start
     observeEvent(input[[colsearch_field]], {
         search <- input[[colsearch_field]]
-        if (identical(search, pObjects$memory[[panel_name]][[.TableColSearch]])) {
+        past <- pObjects$memory[[panel_name]][[.TableColSearch]]
+        if (identical(search, past)) {
             return(NULL)
         }
 
         pObjects$memory[[panel_name]][[.TableColSearch]] <- search
+
+        if (all(search=="") && all(past=="")) {
+            # No update in cases with variable numbers of columns where no
+            # selection was performed (assuming rows were the same).
+            return(NULL)
+        }
+
         .requestActiveSelectionUpdate(panel_name, session, pObjects, rObjects, update_output=FALSE)
     }, ignoreInit=TRUE)
     # nocov end


### PR DESCRIPTION
Avoid unnecessary observer triggering if number of columns changes.