### PR TITLE
Defer definition of CSS classes until we know the Panels.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # iSEE 2.1.17
 
 * `.refineParameters()` for `FeatureAssayPlot`, `SampleAssayPlot` protects the x-axis choice against absent metadata.
+* CSS classes for each panel are now defined at app run-time, to make it easier to write landing pages without specifying `initial=` in `iSEE()`.
 
 # iSEE 2.1.16
 

--- a/R/createLandingPage.R
+++ b/R/createLandingPage.R
@@ -24,8 +24,6 @@
 #' that specifies the initial state of the \code{\link{iSEE}} instance
 #' (to be used as the \code{initial} argument in \code{\link{iSEE}}).
 #' Again, any source can be used to create this list if \code{initUI} and \code{initLoad} are modified appropriately.
-#' Note that only \linkS4class{Panel} classes that were in the original \code{\link{iSEE}()} call
-#' (as the original \code{initial} or in the \code{extra}) will be used for security and other reasons.
 #'
 #' The UI elements for the SummarizedExperiment and the initial state are named \code{"se"} and \code{"initial"} respectively.
 #' This can be used in Shiny bookmarking to initialize an \code{\link{iSEE}} in a desired state by simply clicking a link,

--- a/R/iSEE-main.R
+++ b/R/iSEE-main.R
@@ -424,7 +424,7 @@ iSEE <- function(se,
 
     # Adding CSS classes for all boxes.
     class.def <- .define_box_statuses(c(memory, reservoir))
-    insertUI("iSEE-styles", where="beforeEnd", HTML(class.def))
+    insertUI("#iSEE-styles", where="beforeEnd", HTML(class.def), immediate=TRUE)
 
     # Evaluating certain plots to fill the coordinate list, if there are any
     # multiple selections. This is done in topological order so that all

--- a/R/iSEE-main.R
+++ b/R/iSEE-main.R
@@ -266,17 +266,13 @@ iSEE <- function(se,
 
             # for error message handling
             tags$head(
-                tags$style(
-                    HTML(
-                        paste("
-.shiny-output-error-validation {
+                tags$style(id="iSEE-styles",
+                    HTML(".shiny-output-error-validation {
     font-size: 15px;
     color: forestgreen;
     text-align: center;
 }
-", .define_box_statuses(c(initial, extra))
-                        )
-                    )
+")
                 )
             ),
 
@@ -359,7 +355,7 @@ iSEE <- function(se,
 #' @author Aaron Lun
 #'
 #' @rdname INTERNAL_initialize_server
-#' @importFrom shiny showNotification tagList HTML strong br code
+#' @importFrom shiny showNotification tagList HTML strong br code insertUI
 .initialize_server <- function(se, initial, extra, colormap,
     tour, runLocal, se_name, ecm_name, input, output, session, rObjects)
 {
@@ -425,6 +421,10 @@ iSEE <- function(se,
     }
 
     pObjects <- .create_persistent_objects(memory, reservoir, counter)
+
+    # Adding CSS classes for all boxes.
+    class.def <- .define_box_statuses(c(memory, reservoir))
+    insertUI("iSEE-styles", where="beforeEnd", HTML(class.def))
 
     # Evaluating certain plots to fill the coordinate list, if there are any
     # multiple selections. This is done in topological order so that all

--- a/man/createLandingPage.Rd
+++ b/man/createLandingPage.Rd
@@ -43,8 +43,6 @@ The default landing page also allows users to upload a RDS file containing a lis
 that specifies the initial state of the \code{\link{iSEE}} instance
 (to be used as the \code{initial} argument in \code{\link{iSEE}}).
 Again, any source can be used to create this list if \code{initUI} and \code{initLoad} are modified appropriately.
-Note that only \linkS4class{Panel} classes that were in the original \code{\link{iSEE}()} call
-(as the original \code{initial} or in the \code{extra}) will be used for security and other reasons.
 
 The UI elements for the SummarizedExperiment and the initial state are named \code{"se"} and \code{"initial"} respectively.
 This can be used in Shiny bookmarking to initialize an \code{\link{iSEE}} in a desired state by simply clicking a link,

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -51,6 +51,17 @@ test_that(".getPanelColor returns the expected colors", {
 
 })
 
+test_that(".define_box_statuses generates the CSS classes for each box", {
+
+    out <- iSEE:::.define_box_statuses(list(ReducedDimensionPlot(), FeatureAssayPlot()))
+    expect_match(out, "reduceddimensionplot")
+    expect_match(out, .panelColor(ReducedDimensionPlot()))
+
+    expect_match(out, "featureassayplot")
+    expect_match(out, .panelColor(FeatureAssayPlot()))
+
+})
+
 # utils_class.R ----
 context("Class utilities")
 


### PR DESCRIPTION
This aims to make it easier to write landing pages without also specifying the universe of panels twice (i.e., once in the landing page's `FUN`, and again in the initial call to `iSEE()`).