### PR TITLE
Enable custom saving of the application state.

### DIFF
--- a/R/outputs_general.R
+++ b/R/outputs_general.R
@@ -38,14 +38,17 @@
         )
     })
     # nocov end
+
     # nocov start
     output[[.generalMemoryExport]] <- downloadHandler(
         filename="iSEE_memory.rds",
         content=function(file) {
-            saveRDS(file=file, pObjects$memory)
+            vals <- .gather_current_memory(se, input, pObjects)
+            saveRDS(file=file, vals)
         }
     )
     # nocov end
+
     # nocov start
     output[[.generalExportOutputDownload]] <- downloadHandler(
         filename="iSEE_exports.zip",

--- a/man/iSEE.Rd
+++ b/man/iSEE.Rd
@@ -15,6 +15,7 @@ iSEE(
   runLocal = TRUE,
   voice = FALSE,
   bugs = FALSE,
+  saveState = NULL,
   ...
 )
 }
@@ -47,6 +48,8 @@ If not provided, the app displays the version info of \code{\link{iSEE}}.}
 \item{bugs}{Set to \code{TRUE} to enable the bugs Easter egg.
 Alternatively, a named numeric vector control the respective number of each bug type (e.g., \code{c(bugs=3L, spiders=1L)}).}
 
+\item{saveState}{A function that accepts a single argument containing the current application state and saves it to some appropriate location.}
+
 \item{...}{Further arguments to pass to \code{\link{shinyApp}}.}
 }
 \value{
@@ -70,19 +73,48 @@ Note that \code{initial} will automatically be appended to \code{extra} to form 
 so it is not strictly necessary to re-specify instances of those initial panels in \code{extra}.
 (unless we want the parameters of newly created panels to be different from those at initialization).
 
-The \code{tour} argument needs to be provided in a form compatible with the format expected by the \code{rintrojs} package.
-There should be two columns, \code{element} and \code{intro}, with the former describing the element to highlight and the latter providing some descriptive text - see \url{https://github.com/carlganz/rintrojs#usage} for more information.
-The \code{\link{defaultTour}} also provides the default tour that is used in the Examples below.
-
 By default, categorical data types such as factor and character are limited to 24 levels, beyond which they are coerced to numeric variables for faster plotting.
 This limit may be set to a different value as a global option, e.g. \code{options(iSEE.maxlevels=30)}.
+}
+\section{Setting up a tour}{
+
+The \code{tour} argument allows users to specify a custom tour to walk their audience through various panels.
+This is useful for describing different aspects of the dataset and highlighting interesting points in an interactive manner.
+
+We use the format expected by the \code{rintrojs} package - see \url{https://github.com/carlganz/rintrojs#usage} for more information.
+There should be two columns, \code{element} and \code{intro}, with the former describing the element to highlight and the latter providing some descriptive text. 
+The \code{\link{defaultTour}} also provides the default tour that is used in the Examples below.
+}
+
+\section{Creating a landing page}{
 
 If \code{se} is not supplied, a landing page is generated that allows users to upload their own RDS file to initialize the app.
 By default, the maximum request size for file uploads defaults to 5MB
 (\url{https://shiny.rstudio.com/reference/shiny/0.14/shiny-options.html}).
 To raise the limit (e.g., 50MB), run \code{options(shiny.maxRequestSize=50*1024^2)}.
+
 The \code{landingPage} argument can be used to alter the landing page, see \code{\link{createLandingPage}} for more details.
+This is useful for creating front-ends that can retrieve \linkS4class{SummarizedExperiment}s from a database on demand for interactive visualization.
 }
+
+\section{Saving application state}{
+
+If users want to record the application state, they can download an RDS file containing a list with the entries:
+\itemize{
+\item \code{memory}, a list of \linkS4class{Panel} objects containing the current state of the application.
+This can be directly re-used as the \code{initial} argument in a subsequent \code{\link{iSEE}} call.
+\item \code{se}, the \linkS4class{SummarizedExperiment} object of interest.
+This is optional and may not be present in the list, depending on the user specifications.
+\item \code{colormap}, the \linkS4class{ExperimentColorMap} object being used.
+This is optional and may not be present in the list, depending on the user specifications.
+}
+
+We can also provide a custom function in \code{saveState} that accepts a single argument containing this list.
+This is most useful when \code{\link{iSEE}} is deployed in an enterprise environment where sessions can be saved in a persistent location;
+combined with a suitable \code{landingPage} specification, this allows users to easily reload sessions of interest.
+The idea is very similar to Shiny bookmarks but is more customizable and can be used in conjunction with URL-based bookmarking.
+}
+
 \examples{
 library(scRNAseq)
 

--- a/tests/testthat/test_iSEE-main.R
+++ b/tests/testthat/test_iSEE-main.R
@@ -42,3 +42,11 @@ test_that("iSEE main function runs with empty dimnames", {
     expect_true(any(grepl("colnames.* <- ", out$commands)))
     expect_true(any(grepl("rownames.* <- ", out$commands)))
 })
+
+test_that("iSEE runs correctly with saveState= specified", {
+    app <- iSEE(sce, saveState=function(x) {
+        withProgress(message="Saving!", saveRDS(x, file=tempfile(fileext='.rds')))
+        showNotification("hooray, saved!", type="message")
+    })
+    expect_s3_class(app, "shiny.appobj")
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -264,3 +264,22 @@ test_that("define_visual_options throws an error for unnamed list input", {
         "Visual parameters UI elements must be named"
     )
 })
+
+test_that(".gather_current_memory works as expected", {
+
+    input <- list()
+    input[[iSEE:::.generalMemoryIncludeSE]] <- TRUE
+    input[[iSEE:::.generalMemoryIncludeECM]] <- TRUE
+
+    pObjects <- new.env()
+    pObjects$memory <- list("YAY")
+
+    metadata(sce)$colormap <- "WHEE"
+
+    out <- iSEE:::.gather_current_memory(sce, input, pObjects)
+
+    expect_identical(out$se, sce)
+    expect_identical(out$memory, pObjects$memory)
+    expect_identical(out$colormap, "WHEE")
+
+}

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -282,4 +282,4 @@ test_that(".gather_current_memory works as expected", {
     expect_identical(out$memory, pObjects$memory)
     expect_identical(out$colormap, "WHEE")
 
-}
+})


### PR DESCRIPTION
This allows enterprise deployments to persist the application state, in a manner very similar to Shiny's bookmarking feature but somewhat more flexible with respect to allowing the user to choose where the files ultimately live.