### PR TITLE
Edge-case bugfix to ensure non-NULL SE names for empty SEs.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iSEE
 Title: Interactive SummarizedExperiment Explorer
-Version: 2.3.2
-Date: 2020-11-22
+Version: 2.3.3
+Date: 2020-12-01
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Federico", "Marini", role="aut", email="marinif@uni-mainz.de", comment = c(ORCID = '0000-0003-3252-7758')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# iSEE 2.3.3
+
+* Edge-case bugfix for correct cleaning of zero-row/column SummarizedExperiments.
+
 # iSEE 2.3.2
 
 * Added the `cleanDataset()` generic to ensure all names in the SummarizedExperiment are present and unique.

--- a/R/cleanDataset.R
+++ b/R/cleanDataset.R
@@ -37,16 +37,20 @@ NULL
 #' @rdname cleanDataset
 #' @importFrom SummarizedExperiment rowData colData rowData<- colData<- assayNames assayNames<-
 setMethod("cleanDataset", "SummarizedExperiment", function(se) {
-    if (is.null(rownames(se)) && nrow(se) > 0) {
-        warning("filling in the missing 'rownames(se)'")
+    if (is.null(rownames(se))) {
+        if (nrow(se) > 0) {
+            warning("filling in the missing 'rownames(se)'")
+        }
         rownames(se) <- seq_len(nrow(se))
     } else if (anyDuplicated(rownames(se))) {
         warning("duplicated 'rownames(se)' detected, making them unique")
         rownames(se) <- make.unique(rownames(se))
     }
 
-    if (is.null(colnames(se)) && ncol(se) > 0) {
-        warning("filling in the missing 'colnames(se)'")
+    if (is.null(colnames(se))) {
+        if (ncol(se) > 0) {
+            warning("filling in the missing 'colnames(se)'")
+        }
         colnames(se) <- seq_len(ncol(se))
     } else if (anyDuplicated(colnames(se))) {
         warning("duplicated 'colnames(se)' detected, making them unique")

--- a/tests/testthat/test_clean.R
+++ b/tests/testthat/test_clean.R
@@ -1,7 +1,7 @@
 # This tests the cleanDataset function.
 # library(testthat); library(iSEE); source("test_clean.R")
 
-test_that("cleanDataset does nothing for empties", {
+test_that("cleanDataset makes no noise for empties", {
     expect_warning(cleanDataset(SummarizedExperiment()), NA)
 
     expect_warning(cleanDataset(SingleCellExperiment()), NA)
@@ -18,6 +18,10 @@ test_that("cleanDataset works on row names", {
 
     rownames(se) <- LETTERS[1:10]
     expect_warning(cleanDataset(se), NA)
+
+    # Actually sets empty row names.
+    out <- cleanDataset(SummarizedExperiment())
+    expect_identical(rownames(out), character(0))
 })
 
 test_that("cleanDataset works on column names", {
@@ -31,6 +35,10 @@ test_that("cleanDataset works on column names", {
 
     colnames(se) <- LETTERS[1:10]
     expect_warning(cleanDataset(se), NA)
+
+    # Actually sets empty column names.
+    out <- cleanDataset(SummarizedExperiment())
+    expect_identical(colnames(out), character(0))
 })
 
 test_that("cleanDataset works on colData names", {


### PR DESCRIPTION
Fixes the following:

```r
library(iSEEu)
example(LogFCLogFCPlot)
iSEE(se[,0], list(LogFCLogFCPlot()))
## Something about assigning NULL to ColorBySampleName.
```