### PR TITLE
Fix groupable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iSEE
 Title: Interactive SummarizedExperiment Explorer
-Version: 2.5.1
-Date: 2021-06-07
+Version: 2.5.2
+Date: 2021-07-07
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Federico", "Marini", role="aut", email="marinif@uni-mainz.de", comment = c(ORCID = '0000-0003-3252-7758')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# iSEE 2.5.2
+
+* Bugfix for conversion of categorical columns with too many levels to numeric ones
+
 # iSEE 2.5.1
 
 * Bugfix for removed panels showing up among the selectable ones.

--- a/R/family_ColumnDotPlot.R
+++ b/R/family_ColumnDotPlot.R
@@ -244,7 +244,7 @@ setMethod(".cacheCommonInfo", "ColumnDotPlot", function(x, se) {
     displayable <- .findAtomicFields(df)
 
     subdf <- df[,displayable,drop=FALSE]
-    discrete <- .whichGroupable(subdf)
+    discrete <- .whichGroupable(subdf, max_levels = .get_factor_maxlevels())
     continuous <- .whichNumeric(subdf)
 
     .setCachedCommonInfo(se, "ColumnDotPlot",

--- a/R/family_RowDotPlot.R
+++ b/R/family_RowDotPlot.R
@@ -242,7 +242,7 @@ setMethod(".cacheCommonInfo", "RowDotPlot", function(x, se) {
     displayable <- .findAtomicFields(df)
 
     subdf <- df[,displayable,drop=FALSE]
-    discrete <- .whichGroupable(subdf)
+    discrete <- .whichGroupable(subdf, max_levels = .get_factor_maxlevels())
     continuous <- .whichNumeric(subdf)
 
     .setCachedCommonInfo(se, "RowDotPlot",

--- a/R/panel_ComplexHeatmapPlot.R
+++ b/R/panel_ComplexHeatmapPlot.R
@@ -372,13 +372,13 @@ setMethod(".cacheCommonInfo", "ComplexHeatmapPlot", function(x, se) {
     df <- colData(se)
     coldata_displayable <- .findAtomicFields(df)
     subdf <- df[,coldata_displayable,drop=FALSE]
-    coldata_discrete <- .whichGroupable(subdf)
+    coldata_discrete <- .whichGroupable(subdf, max_levels = .get_color_maxlevels())
     coldata_continuous <- .whichNumeric(subdf)
 
     df <- rowData(se)
     rowdata_displayable <- .findAtomicFields(df)
     subdf <- df[,rowdata_displayable,drop=FALSE]
-    rowdata_discrete <- .whichGroupable(subdf)
+    rowdata_discrete <- .whichGroupable(subdf, max_levels = .get_color_maxlevels())
     rowdata_continuous <- .whichNumeric(subdf)
 
     .setCachedCommonInfo(se, "ComplexHeatmapPlot",


### PR DESCRIPTION
With the move to registerAppOptions, it seems the recognition of the maximum number of allowed values before a categorical variable was converted into a numeric one was not working any more for facetting, shape/size by and heatmap annotations (dot plot axes and coloring were fine). I think this should fix the issue.