### PR TITLE
Bugfix setting the active multi-selection info of Table panels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iSEE
 Title: Interactive SummarizedExperiment Explorer
-Version: 2.9.3
-Date: 2022-07-20
+Version: 2.9.4
+Date: 2022-07-23
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Federico", "Marini", role="aut", email="marinif@uni-mainz.de", comment = c(ORCID = '0000-0003-3252-7758')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Bugfix setting the active multi-selection info of `Table` panels to a fixed
   message, as the panel is not re-rendered when search boxes are used.
+* Bugfix re-rendering `ComplexHeatmapPlot` panels when displaying incoming
+  column selection.
 
 # iSEE 2.9.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# iSEE 2.9.4
+
+* Bugfix setting the active multi-selection info of `Table` panels to a fixed
+  message, as the panel is not re-rendered when search boxes are used.
+
 # iSEE 2.9.3
 
 * Partial bugfix avoiding re-rendering of `ComplexHeatmapPlot` panel

--- a/R/outputs_info.R
+++ b/R/outputs_info.R
@@ -34,8 +34,15 @@
         env <- new.env()
         env$contents <- cur_coords
         env$se <- se
-
-        if (.multiSelectionHasActive(instance)) {
+        
+        if (is(instance, "Table")) {
+            all_output <- append(all_output,
+                list(
+                    "Active selection shown below table (if any).",
+                    br()
+                )
+            )
+        } else if (.multiSelectionHasActive(instance)) {
             env$select <- .multiSelectionActive(instance)
             cmds <- .multiSelectionCommands(instance, NA)
             .textEval(cmds, env)

--- a/R/panel_ComplexHeatmapPlot.R
+++ b/R/panel_ComplexHeatmapPlot.R
@@ -743,7 +743,8 @@ setMethod(".hideInterface", "ComplexHeatmapPlot", function(x, field) {
 
 #' @export
 setMethod(".multiSelectionRestricted", "ComplexHeatmapPlot", function(x) {
-    !slot(x, .heatMapCustomFeatNames) || slot(x, .selectColRestrict)
+    ## .heatMapShowSelection is not technically restricted, but requires rerendering nonetheless
+    !slot(x, .heatMapCustomFeatNames) || slot(x, .selectColRestrict) || slot(x, .heatMapShowSelection)
 })
 
 ###############################################################

--- a/tests/testthat/test_api.R
+++ b/tests/testthat/test_api.R
@@ -140,6 +140,12 @@ test_that(".multiSelectionRestricted handles Tables", {
     expect_true(out)
 })
 
+test_that(".multiSelectionRestricted handles ComplexHeatmapPlot", {
+    x <- ComplexHeatmapPlot()
+    out <- .multiSelectionRestricted(x)
+    expect_true(out)
+})
+
 # .multiSelectionClear ----
 context(".multiSelectionClear")
 


### PR DESCRIPTION
Table panels are not re-rendered when their search boxes are used to filter them (otherwise, it would create that annoying effect of the cursor losing the focus from the search box are each character typed because the cursor does not refocus on the search box after the panel is re-rendered).

This means that the info message indicating the number and fraction of rows selected is out-of-date most of the time (it is only updated if the table panel is re-rendered due to an incoming selection forcing the table panel to re-render due to repopulation of the table.

This fix... fixes the content of the ui info for Table panels to a message that redirects users to the `DT::datatable` built-in message that already reports that information.